### PR TITLE
Adding Mitigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,23 @@ sh-4.2# id
 uid=0(root) gid=0(root) groups=0(root),11000(user) context=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023
 sh-4.2# exit
 ```
+## About Polkit pkexec for Linux
+
+Polkit (formerly PolicyKit) is a component for controlling system-wide privileges in Unix-like operating systems. It provides an organized way for non-privileged processes to communicate with privileged processes. It is also possible to use polkit to execute commands with elevated privileges using the command pkexec followed by the command intended to be executed (with root permission).
+
+
+# Mitigation
+
+If no patches are available for your operating system, you can remove the SUID-bit from pkexec as a temporary mitigation.
+```bash
+# chmod 0755 /usr/bin/pkexec
+```
+
+The exploit then will fail complaining that `pkexec` must have the
+setuid bit enabled.
+```bash
+xd@The-Watcher:~$ sudo chmod 0755 /usr/bin/pkexec
+xd@The-Watcher:~$ ./cve-2021-4034
+GLib: Cannot convert message: Could not open converter from “UTF-8” to “PWNKIT”
+pkexec must be setuid root
+```


### PR DESCRIPTION
# Mitigation

If no patches are available for your operating system, you can remove the SUID-bit from pkexec as a temporary mitigation.
```bash
# chmod 0755 /usr/bin/pkexec
```